### PR TITLE
Keep geocoder in version 1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,8 @@ gem 'bootsnap', '~> 1.3'
 # can't update until decicim-dev is higher gem 'puma', '~> 4.3'
 gem 'puma', '~> 3.12'
 gem 'uglifier', '~> 4.1'
-
+# geocoder can not be upgraded to 1.6 until the Here maps api key is changed for the new one
+gem "geocoder", "~> 1.5.2"
 
 gem 'httplog'
 gem "deface"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -825,6 +825,7 @@ DEPENDENCIES
   deface
   delayed_job_active_record
   faker (~> 1.9)
+  geocoder (~> 1.5.2)
   httplog
   letter_opener_web (~> 1.3)
   listen (~> 3.1)


### PR DESCRIPTION
Keep geocoder in version 1.5 to stay with the legacy HERE-maps api credentials