### PR TITLE
Do not declare omniauth providers in initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ user.save!
 
 You're good to go!
 
+## TODO
+
+Until Decidim v0.22 is released an initializer to configure the SAML integration is kept in `config/initializers/omniauth.rb`.
+When upgrading to v0.22 which includes the fix https://github.com/decidim/decidim/pull/6042 the initializer should be removed and the configuration in `config/secrets.yml` should be reviewed.
+
 ## SAML integration
 
 The [ruby-saml](https://github.com/onelogin/ruby-saml) gem allows to integrate a SAML single sign on strategy.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -17,23 +17,23 @@ end
 
 Rails.logger.info "SAML ENABLED? #{Rails.application.secrets.dig(:omniauth, :saml, :enabled)}"
 if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
-  # Devise.setup do |config|
-  #   config.omniauth :saml,
-  #                   idp_cert: Chamber.env.saml.idp_cert,
-  #                   idp_sso_target_url: Chamber.env.saml.idp_sso_target_url,
-  #                   sp_entity_id: Chamber.env.saml.sp_entity_id,
-  #                   strategy_class: ::OmniAuth::Strategies::SAML,
-  #                   attribute_statements: {
-  #                     email: ['mail'],
-  #                     name: ['givenName', 'nom']
-  #                   },
-  #                   certificate: Chamber.env.saml.certificate,
-  #                   private_key: Chamber.env.saml.private_key,
-  #                   security: {
-  #                     authn_requests_signed: true,
-  #                     signature_method: XMLSecurity::Document::RSA_SHA256
-  #                   }
-  # end
+  Devise.setup do |config|
+    config.omniauth :saml,
+                    idp_cert: Chamber.env.saml.idp_cert,
+                    idp_sso_target_url: Chamber.env.saml.idp_sso_target_url,
+                    sp_entity_id: Chamber.env.saml.sp_entity_id,
+                    strategy_class: ::OmniAuth::Strategies::SAML,
+                    attribute_statements: {
+                      email: ['mail'],
+                      name: ['givenName', 'nom']
+                    },
+                    certificate: Chamber.env.saml.certificate,
+                    private_key: Chamber.env.saml.private_key,
+                    security: {
+                      authn_requests_signed: true,
+                      signature_method: XMLSecurity::Document::RSA_SHA256
+                    }
+  end
 
   Devise::OmniauthCallbacksController.class_eval do
     skip_before_action :verify_authenticity_token

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
 
 if Rails.application.secrets.dig(:omniauth, :imipre, :enabled)
-  module OmniAuth
-    module Strategies
-      # tell OmniAuth to load our strategy
-      autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
-    end
-  end
+  # module OmniAuth
+  #   module Strategies
+  #     # tell OmniAuth to load our strategy
+  #     autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
+  #   end
+  # end
 
-  Devise.setup do |config|
-    config.omniauth :imipre, scope: Chamber.env.imipre.scope, domain: Chamber.env.imipre.domain
-  end
+  # Devise.setup do |config|
+  #   config.omniauth :imipre, scope: Chamber.env.imipre.scope, domain: Chamber.env.imipre.domain
+  # end
 
-  Decidim::User.omniauth_providers << :imipre
+  # Decidim::User.omniauth_providers << :imipre
 end
 
 Rails.logger.info "SAML ENABLED? #{Rails.application.secrets.dig(:omniauth, :saml, :enabled)}"
 if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
-  Devise.setup do |config|
-    config.omniauth :saml,
-                    idp_cert: Chamber.env.saml.idp_cert,
-                    idp_sso_target_url: Chamber.env.saml.idp_sso_target_url,
-                    sp_entity_id: Chamber.env.saml.sp_entity_id,
-                    strategy_class: ::OmniAuth::Strategies::SAML,
-                    attribute_statements: {
-                      email: ['mail'],
-                      name: ['givenName', 'nom']
-                    },
-                    certificate: Chamber.env.saml.certificate,
-                    private_key: Chamber.env.saml.private_key,
-                    security: {
-                      authn_requests_signed: true,
-                      signature_method: XMLSecurity::Document::RSA_SHA256
-                    }
-  end
+  # Devise.setup do |config|
+  #   config.omniauth :saml,
+  #                   idp_cert: Chamber.env.saml.idp_cert,
+  #                   idp_sso_target_url: Chamber.env.saml.idp_sso_target_url,
+  #                   sp_entity_id: Chamber.env.saml.sp_entity_id,
+  #                   strategy_class: ::OmniAuth::Strategies::SAML,
+  #                   attribute_statements: {
+  #                     email: ['mail'],
+  #                     name: ['givenName', 'nom']
+  #                   },
+  #                   certificate: Chamber.env.saml.certificate,
+  #                   private_key: Chamber.env.saml.private_key,
+  #                   security: {
+  #                     authn_requests_signed: true,
+  #                     signature_method: XMLSecurity::Document::RSA_SHA256
+  #                   }
+  # end
 
   Devise::OmniauthCallbacksController.class_eval do
     skip_before_action :verify_authenticity_token
@@ -67,7 +67,7 @@ if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
     end
   end
 
-  Decidim::User.omniauth_providers << :saml
+  # Decidim::User.omniauth_providers << :saml
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -35,8 +35,19 @@ default: &default
       enabled: true
       idp_cert: <%= Chamber.env.saml.idp_cert %>
       idp_sso_target_url: <%= Chamber.env.saml.idp_sso_target_url %>
-      certificate: <%= Chamber.env.saml.certificate %>
       sp_entity_id: <%= Chamber.env.saml.sp_entity_id %>
+      strategy_class: <%= ::OmniAuth::Strategies::SAML %>
+      attribute_statements:
+        email:
+          - mail
+        name:
+          - givenName
+          - nom
+      certificate: <%= Chamber.env.saml.certificate %>
+      private_key: <%= Chamber.env.saml.private_key %>
+      security:
+        authn_requests_signed: true
+        signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
   geocoder:
     geocoder_lookup_app_id: <%= Chamber.env.geocoder_lookup_app_id %>
     geocoder_lookup_app_code: <%= Chamber.env.geocoder_lookup_app_code %>


### PR DESCRIPTION
Decidim v0.21 requires a specific configuration for omniauth providers. This PR reconfigures this installation as required.