### PR TITLE
Remove commented imipre initializer

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+if Rails.application.secrets.dig(:omniauth, :imipre, :enabled)
+  module OmniAuth
+    module Strategies
+      # tell OmniAuth to load our strategy
+      autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
+    end
+  end
+end
+
 Rails.logger.info "SAML ENABLED? #{Rails.application.secrets.dig(:omniauth, :saml, :enabled)}"
 if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
   Devise.setup do |config|

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,20 +1,5 @@
 # frozen_string_literal: true
 
-if Rails.application.secrets.dig(:omniauth, :imipre, :enabled)
-  # module OmniAuth
-  #   module Strategies
-  #     # tell OmniAuth to load our strategy
-  #     autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
-  #   end
-  # end
-
-  # Devise.setup do |config|
-  #   config.omniauth :imipre, scope: Chamber.env.imipre.scope, domain: Chamber.env.imipre.domain
-  # end
-
-  # Decidim::User.omniauth_providers << :imipre
-end
-
 Rails.logger.info "SAML ENABLED? #{Rails.application.secrets.dig(:omniauth, :saml, :enabled)}"
 if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
   Devise.setup do |config|

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,6 +30,8 @@ default: &default
       client_id: <%= Chamber.env.imipre.client_id %>
       client_secret: <%= Chamber.env.imipre.client_secret %>
       site_url: <%= Chamber.env.imipre.site_url %>
+      scope: <%= Chamber.env.imipre.scope %>
+      domain: <%= Chamber.env.imipre.domain %>
       icon_path: Oauth_logo.svg
     saml:
       enabled: true
@@ -58,9 +60,6 @@ development:
   omniauth:
     imipre:
       enabled: false
-      client_id: <%= Chamber.env.imipre.client_id %>
-      client_secret: <%= Chamber.env.imipre.client_secret %>
-      icon_path: Oauth_logo.svg
     saml:
       enabled: false
       idp_cert_fingerprint: <%= Chamber.env.saml.idp_cert_fingerprint %>


### PR DESCRIPTION
Since Decidim v0.21 OAuth2 initialization has moved from initializers into Rails secrets.
This PR gets rid of Imipre's configuration via initializer.

Integration via SAML requires a more complex initialization and should be kept.